### PR TITLE
Allow category to be unset when editing

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -188,6 +188,4 @@ This is roughly equivalent to having a `passwords.txt` file on your desktop: you
 
 ## Known Issues
 
-- Once a category on a credential is set, you can no longer set it back to the empty string:
-  when editing, leaving a field blank retains its old value.
 - Code style likely isn't very good -- comments and pointers much appreciated!

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,9 +292,7 @@ fn modify_credential_data(cred: &mut Credential, skip_name_and_category: bool) {
             "" => "Category: ".to_owned(),
             x => format!("Category [{}]: ", x)
         }.as_ref()).unwrap();
-        if category != "" {
-            cred.category = category;
-        }
+        cred.category = category;
     }
     let username = rl.readline(match cred.username.as_ref() {
         "" => "Username: ".to_owned(),


### PR DESCRIPTION
This was listed as a known issue and the fix was something that was easy to tackle.

To unset a category, you can now use `pw edit my-credential` and skip entering a category.